### PR TITLE
add `clear_outputs` param

### DIFF
--- a/livelossplot/core.py
+++ b/livelossplot/core.py
@@ -15,8 +15,10 @@ def check_inline():
 def draw_plot(logs, metrics, figsize=None, max_epoch=None,
               max_cols=2,
               validation_fmt="val_{}",
-              metric2title={}):
-    clear_output(wait=True)
+              metric2title={}, 
+              clear_outputs=True):
+    if clear_outputs: 
+      clear_output(wait=True)
     plt.figure(figsize=figsize)
 
     for metric_id, metric in enumerate(metrics):

--- a/livelossplot/generic_plot.py
+++ b/livelossplot/generic_plot.py
@@ -4,7 +4,7 @@ from .core import draw_plot
 
 class PlotLosses():
     def __init__(self, figsize=None, cell_size=(6, 4), dynamic_x_axis=False, max_cols=2, max_epoch=None, metric2title={},
-    validation_fmt="val_{}"):
+    validation_fmt="val_{}", clear_outputs=True):
         self.figsize = figsize
         self.cell_size = cell_size
         self.dynamic_x_axis = dynamic_x_axis
@@ -13,6 +13,7 @@ class PlotLosses():
         self.metric2title = metric2title
         self.validation_fmt = validation_fmt
         self.logs = None
+        self.clear_outputs = clear_outputs
 
     def set_metrics(self, metrics):
         self.base_metrics = metrics
@@ -34,4 +35,5 @@ class PlotLosses():
                   figsize=self.figsize, max_epoch=self.max_epoch,
                   max_cols=self.max_cols,
                   validation_fmt=self.validation_fmt,
-                  metric2title=self.metric2title)
+                  metric2title=self.metric2title,
+                  clear_outputs = self.clear_outputs)

--- a/livelossplot/keras_plot.py
+++ b/livelossplot/keras_plot.py
@@ -24,12 +24,13 @@ def loss2name(loss):
         return loss
 
 class PlotLossesKeras(Callback):
-    def __init__(self, figsize=None, cell_size=(6, 4), dynamic_x_axis=False, max_cols=2):
+    def __init__(self, figsize=None, cell_size=(6, 4), dynamic_x_axis=False, max_cols=2, clear_outputs=True):
         self.figsize = figsize
         self.cell_size = cell_size
         self.dynamic_x_axis = dynamic_x_axis
         self.max_cols = max_cols
         self.metric2printable = metric2printable.copy()
+        self.clear_outputs = clear_outputs
 
     def on_train_begin(self, logs={}):
         self.base_metrics = [metric for metric in self.params['metrics'] if not metric.startswith('val_')]
@@ -62,4 +63,5 @@ class PlotLossesKeras(Callback):
                   figsize=self.figsize, max_epoch=self.max_epoch,
                   max_cols=self.max_cols,
                   validation_fmt="val_{}",
-                  metric2title=self.metric2printable)
+                  metric2title=self.metric2printable,
+                  clear_outputs = self.clear_outputs)


### PR DESCRIPTION
This adds a parameter to control whether plots are cleared on each iteration. I found this particularly useful when doing cross validation, and this also addresses issue #2 