### PR TITLE
Add support for unicode in README.md

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 from setuptools import setup, find_packages
-import codecs
 
 def readme():
-    with codecs.open('README.md', encoding='utf-8') as f:
+    with open('README.md', encoding='utf-8') as f:
         return f.read()
 
 setup(name='livelossplot',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 from setuptools import setup, find_packages
+import codecs
 
 def readme():
-    with open('README.md') as f:
+    with codecs.open('README.md', encoding='utf-8') as f:
         return f.read()
 
 setup(name='livelossplot',


### PR DESCRIPTION
In setup.py, the contents of README.md are read as a string,
but this fails because it contains a unicode character. By using
the codecs library, the unicode character can be included in the
string.

I wasn't sure if I needed to do anything special to import other packages in setup.py.
Let me know if there's something I need to change.