### PR TITLE
Quickfix for turning dict values into an indexable list

### DIFF
--- a/livelossplot/keras_plot.py
+++ b/livelossplot/keras_plot.py
@@ -46,7 +46,7 @@ class PlotLossesKeras(Callback):
         if isinstance(self.model.loss, list):
             losses = self.model.loss
         elif isinstance(self.model.loss, dict):
-            losses = self.model.loss.values()
+            losses = list(self.model.loss.values())
         else:
             # by far the most common scenario
             losses = [self.model.loss]


### PR DESCRIPTION
Hi there,

Just sending in a quick fix of a TypeError I encountered, somewhat related to stared/livelossplot#3. Problematic lines are at [here](https://github.com/stared/livelossplot/blob/128931c095d3d882d8e31c3a14f12c49fb870f72/livelossplot/keras_plot.py#L48-L54).

Error message:

```python
~/.local/share/virtualenvs/.../lib/python3.6/site-packages/livelossplot/keras_plot.py in on_train_begin(self, logs)
     52             losses = [self.model.loss]
     53 
---> 54         loss_name = loss2name(losses[0])
     55         self.metric2printable['loss'] = "{} (cost function)".format(self.metric2printable.get(loss_name, loss_name))
     56         if len(losses) > 1:

TypeError: 'dict_values' object does not support indexing
```

This is a [Python 2 to 3 problem](https://stackoverflow.com/questions/16228248/how-can-i-get-list-of-values-from-dict/16228268#16228268). Calling dict.values() in Python3 returns a 'dict_values' object (which cannot be indexed) instead of a list, so the solution is to explicitly set it as a list using `losses = list(self.model.loss.values())` in the early part of the code.