### PR TITLE
Use Tensorflow's Keras sub-package if the Keras package is not available.

### DIFF
--- a/livelossplot/keras_plot.py
+++ b/livelossplot/keras_plot.py
@@ -1,6 +1,9 @@
 from __future__ import division
 
-from keras.callbacks import Callback
+try:
+    from keras.callbacks import Callback
+except ImportError:
+    from tensorflow.keras.callbacks import Callback
 from .generic_plot import PlotLosses
 
 metric2printable = {


### PR DESCRIPTION
Hey :-) Thanks, for livelossplot!

The Tensorflow Python package includes a keras sub-package. If one only wants to use Keras with the Tensorflow backend, it is not necessary to install the Keras package, but one can use the sub-package.