### PR TITLE
fix underscores in metric name

### DIFF
--- a/livelossplot/core.py
+++ b/livelossplot/core.py
@@ -90,14 +90,15 @@ def print_extrema(logs,
             serie_metric_name = serie_fmt.format(metric)
             serie_metric_logs = [log[serie_metric_name] for log in logs if serie_metric_name in log]
 
-            log = serie_log_fmt.format(
-                min=extrema[serie_metric_name].get('min'),
-                max=extrema[serie_metric_name].get('max'),
-                cur=serie_metric_logs[-1])
+            if len(serie_metric_logs) > 0:
+                log = serie_log_fmt.format(
+                    min=extrema[serie_metric_name].get('min'),
+                    max=extrema[serie_metric_name].get('max'),
+                    cur=serie_metric_logs[-1])
 
-            if i == 0:
-                extrema_logs.append(metric2title.get(metric, metric) + ':' + log)
-            else:
-                extrema_logs[-1] += log
+                if i == 0:
+                    extrema_logs.append(metric2title.get(metric, metric) + ':' + log)
+                else:
+                    extrema_logs[-1] += log
 
     print('\n\n'.join(extrema_logs))

--- a/livelossplot/generic_plot.py
+++ b/livelossplot/generic_plot.py
@@ -86,10 +86,15 @@ class PlotLosses():
                 if _is_unset(extrema['max']) or value > extrema['max']:
                     extrema['max'] = float(value)
 
+    def _get_metric(self, log_metric):
+        for format_string in reversed(sorted(list(self.series_fmt.values()), key=len)):
+            if log_metric.startswith(format_string.replace('{}','')):
+                return log_metric[len(format_string.replace('{}','')):]
+			
     def update(self, log, step=1):
         self.global_step += step
         if self.logs is None:
-            self.set_metrics(list(OrderedDict.fromkeys([metric.split('_')[-1] for metric in log.keys()])))
+            self.set_metrics(list(OrderedDict.fromkeys([self._get_metric(log_metric) for log_metric in log.keys()])))
 
         log["_i"] = self.global_step
         self.logs.append(log)


### PR DESCRIPTION
While it fixes the underscores in metric name, it does not fix the issue mentionned in #56 because it is a different issue, IMHO not related to custom series, but rather to lr appearing dynamically in logs while not having set in on_train_begin.

Either lr is not a metric, and I would change line 82 in generic_plot.py as such:
replace `if metric != "_i":` by `if metric in self.metrics_extrema:`

Or lr is a valid metric, and set_metrics should be adapted in on_train_begin or most probably in on_epoch_end. But I'll leave this one to you @stared 

Content of logs and base_metrics just before the error in _update_extrema:
logs={'val_loss': 0.30390482946038244, 'val_acc': 0.9154, 'val_mean_squared_error': 0.01308123045139946, 'loss': 0.44024413793881734, 'acc': 0.8819166666666667, 'mean_squared_error': 0.019188156543609995, **'lr': 0.001**, '_i': 1}
base_metrics=['loss', 'acc', 'mean_squared_error'] => so there's no 'lr'