### PR TITLE
Replace the `:` character in Tensorboard path if the platform is Windows

### DIFF
--- a/livelossplot/tensorboard.py
+++ b/livelossplot/tensorboard.py
@@ -1,3 +1,4 @@
+import sys
 import tensorflow as tf
 from datetime import datetime
 from os import path
@@ -5,6 +6,8 @@ from os import path
 class TensorboardLogger:
     def __init__(self, logdir="./tensorboard_logs/"):
         time_str = datetime.now().isoformat()[:-7].replace("T", " ")
+        if sys.platform == "win32":
+            time_str = time_str.replace(":", "_")
         self._path = path.join(logdir, time_str)
         self.writer = tf.summary.FileWriter(self._path)
 
@@ -20,4 +23,3 @@ class TensorboardLogger:
     def log_logs(self, logs, global_step):
         for k, v in logs.items():
             self.log_scalar(k, v, global_step)
-

--- a/livelossplot/tensorboard.py
+++ b/livelossplot/tensorboard.py
@@ -1,13 +1,10 @@
-import sys
 import tensorflow as tf
 from datetime import datetime
 from os import path
 
 class TensorboardLogger:
     def __init__(self, logdir="./tensorboard_logs/"):
-        time_str = datetime.now().isoformat()[:-7].replace("T", " ")
-        if sys.platform == "win32":
-            time_str = time_str.replace(":", "_")
+        time_str = datetime.now().isoformat()[:-7].replace("T", " ").replace(":", "_")
         self._path = path.join(logdir, time_str)
         self.writer = tf.summary.FileWriter(self._path)
 


### PR DESCRIPTION
The OS is detected using `sys.platform`. From the official documentation (https://docs.python.org/3/library/sys.html#sys.platform), the value will be "win32" for any windows implementation, except Cygwin.
It seems that Cygwin has its own way of handling special characters, and should behave like any POSIX compliant system regarding path special characters.