### PR TITLE
GH Actions regrouping

### DIFF
--- a/.github/workflows/external_packages.yml
+++ b/.github/workflows/external_packages.yml
@@ -13,24 +13,17 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7]
-
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.7
     - name: Install package and dev dependencies
       run: |
         python -m pip install --upgrade pip
         python setup.py install
         pip install -r requirements-dev.txt
-    - name: Test with pytest
-      run: |
-        pytest
     - name: Test TensorBoard output
       run: |
         pip install tensorflow

--- a/.github/workflows/flake8_yapf.yml
+++ b/.github/workflows/flake8_yapf.yml
@@ -1,0 +1,36 @@
+name: Flake8 and yapf
+
+on:
+ push:
+   branches: [ master ]
+ pull_request:
+   branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        pip install flake8
+        pin pnstall yapf
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings.
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
+    - name: yapf
+      id: yapf
+      uses: diegovalenzuelaiturra/yapf-action@v0.0.1
+      with:
+        args: . --recursive --diff
+    - name: Fail if yapf made changes
+      if: steps.yapf.outputs.exit-code == 2
+      run: exit 1

--- a/.github/workflows/flake8_yapf.yml
+++ b/.github/workflows/flake8_yapf.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install flake8
-        pin pnstall yapf
+        pip install yapf
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -28,20 +28,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
         python setup.py install
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings.
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=120 --statistics
     - name: Test with pytest
       run: |
         pytest
-    - name: yapf
-      id: yapf
-      uses: diegovalenzuelaiturra/yapf-action@v0.0.1
-      with:
-        args: . --recursive --diff
-    - name: Fail if yapf made changes
-      if: steps.yapf.outputs.exit-code == 2
-      run: exit 1


### PR DESCRIPTION
Flake8 and YAPF do not depend on Python version, so I separated that.

I consider splitting `external_packages.yaml` into environments, to make it parallel, and easier to spot errors. 