### PR TITLE
Improving API with to_matplotlib(...) and related

### DIFF
--- a/livelossplot/__init__.py
+++ b/livelossplot/__init__.py
@@ -9,6 +9,12 @@ from .inputs import *
 from . import outputs
 from .version import __version__
 
+
+"""livelossplot
+
+Main repository: <https://github.com/stared/livelossplot>
+"""
+
 _input_plugin_dict = {
     'keras': 'Keras',
     'tf_keras': 'KerasTF',

--- a/livelossplot/__init__.py
+++ b/livelossplot/__init__.py
@@ -1,3 +1,7 @@
+"""
+.. include:: ../README.md
+"""
+
 import sys
 import warnings
 from importlib.util import find_spec
@@ -8,12 +12,6 @@ from . import inputs
 from .inputs import *
 from . import outputs
 from .version import __version__
-
-
-"""livelossplot
-
-Main repository: <https://github.com/stared/livelossplot>
-"""
 
 _input_plugin_dict = {
     'keras': 'Keras',

--- a/livelossplot/inputs/__init__.py
+++ b/livelossplot/inputs/__init__.py
@@ -1,7 +1,7 @@
 def PlotLossesKeras(**kwargs):
     """PlotLosses callback for Keras (as a standalone library).
     Args:
-        kwargs: key-arguments which are passed to PlotLosses
+        **kwargs: key-arguments which are passed to PlotLosses
 
     Notes:
         Requires keras to be installed.
@@ -13,7 +13,7 @@ def PlotLossesKeras(**kwargs):
 def PlotLossesKerasTF(**kwargs):
     """PlotLosses callback for Keras (as a module of TensorFlow).
     Args:
-        kwargs: key-arguments which are passed to PlotLosses
+        **kwargs: key-arguments which are passed to PlotLosses
 
     Notes:
         Requires tensorflow to be installed.
@@ -25,7 +25,7 @@ def PlotLossesKerasTF(**kwargs):
 def PlotLossesPoutyne(**kwargs):
     """PlotLosses callback for Poutyne, a library for PyTorch.
     Args:
-        kwargs: key-arguments which are passed to PlotLosses
+        **kwargs: key-arguments which are passed to PlotLosses
 
     Notes:
         Requires poutyne to be installed, https://poutyne.org/.
@@ -37,7 +37,7 @@ def PlotLossesPoutyne(**kwargs):
 def PlotLossesIgnite(**kwargs):
     """PlotLosses callback for Poutyne, a library for PyTorch.
     Args:
-        kwargs: key-arguments which are passed to PlotLosses
+        **kwargs: key-arguments which are passed to PlotLosses
 
     Notes:
         Requires pytorch-ignite to be installed, https://github.com/pytorch/ignite.

--- a/livelossplot/inputs/__init__.py
+++ b/livelossplot/inputs/__init__.py
@@ -1,5 +1,5 @@
 def PlotLossesKeras(**kwargs):
-    """PlotLosses callback for Keras (as a standalone library).
+    """PlotLosses callback for Keras (as a standalone library, not a TensorFlow module).
     Args:
         **kwargs: key-arguments which are passed to PlotLosses
 
@@ -35,12 +35,12 @@ def PlotLossesPoutyne(**kwargs):
 
 
 def PlotLossesIgnite(**kwargs):
-    """PlotLosses callback for Poutyne, a library for PyTorch.
+    """PlotLosses callback for PyTorch-Ignite, a library for PyTorch.
     Args:
         **kwargs: key-arguments which are passed to PlotLosses
 
     Notes:
-        Requires pytorch-ignite to be installed, https://github.com/pytorch/ignite.
+        Requires pytorch-ignite to be installed, <https://github.com/pytorch/ignite>.
     """
     from .pytorch_ignite import PlotLossesCallback
     return PlotLossesCallback(**kwargs)

--- a/livelossplot/inputs/__init__.py
+++ b/livelossplot/inputs/__init__.py
@@ -28,7 +28,7 @@ def PlotLossesPoutyne(**kwargs):
         **kwargs: key-arguments which are passed to PlotLosses
 
     Notes:
-        Requires poutyne to be installed, https://poutyne.org/.
+        Requires poutyne to be installed, <https://poutyne.org/>.
     """
     from .poutyne import PlotLossesCallback
     return PlotLossesCallback(**kwargs)

--- a/livelossplot/outputs/neptune_logger.py
+++ b/livelossplot/outputs/neptune_logger.py
@@ -12,7 +12,7 @@ class NeptuneLogger(BaseOutput):
         Args:
             api_token: your api token, you can create NEPTUNE_API_TOKEN environment variable instead
             project_qualified_name: <user>/<project>, you can create NEPTUNE_PROJECT environment variable instead
-            kwargs: keyword args, that will be passed to create_experiment function
+            **kwargs: keyword args, that will be passed to create_experiment function
         """
         import neptune
         self.neptune = neptune

--- a/livelossplot/plot_losses.py
+++ b/livelossplot/plot_losses.py
@@ -1,6 +1,7 @@
 import warnings
 from typing import Type, TypeVar, List, Union
 
+import livelossplot
 from livelossplot.main_logger import MainLogger
 from livelossplot import outputs
 
@@ -26,7 +27,7 @@ class PlotLosses:
             **kwargs: key-arguments which are passed to MainLogger constructor
         """
         self.logger = MainLogger(**kwargs)
-        self.outputs = [getattr(outputs, out)() if isinstance(out, str) else out for out in outputs]
+        self.outputs = [getattr(livelossplot.outputs, out)() if isinstance(out, str) else out for out in outputs]
         for out in self.outputs:
             out.set_output_mode(mode)
 

--- a/livelossplot/plot_losses.py
+++ b/livelossplot/plot_losses.py
@@ -37,3 +37,30 @@ class PlotLosses:
         """Send method substitute from old livelossplot api"""
         warnings.warn('draw will be deprecated, please use send method', PendingDeprecationWarning)
         self.send()
+
+    def reset_outputs(self) -> PlotLosses:
+        """Resets all outputs.
+
+        Returns:
+            Plotlosses object (so it works for chaining)
+        """
+        self.outputs = []
+        return self
+
+    def to_matplotlib(self, *args, **kwargs) -> PlotLosses:
+        """Appends outputs.MatplotlibPlot output, with specified parameters.
+
+        Returns:
+            Plotlosses object (so it works for chaining)
+        """
+        self.outputs.append(MatplotlibPlot(*args, **kwargs))
+        return self
+
+    def to_extrema_printer(self, *args, **kwargs) -> PlotLosses:
+        """Appends outputs.ExtremaPrinter output, with specified parameters.
+
+        Returns:
+            Plotlosses object (so it works for chaining)
+        """
+        self.outputs.append(ExtremaPrinter(*args, **kwargs))
+        return self

--- a/livelossplot/plot_losses.py
+++ b/livelossplot/plot_losses.py
@@ -53,20 +53,74 @@ class PlotLosses:
         self.outputs = []
         return self
 
-    def to_matplotlib(self, *args, **kwargs) -> 'PlotLosses':
+    def to_matplotlib(self, **kwargs) -> 'PlotLosses':
         """Appends outputs.MatplotlibPlot output, with specified parameters.
 
+        Args:
+            **kwargs: keyword arguments for MatplotlibPlot
+
         Returns:
             Plotlosses object (so it works for chaining)
         """
-        self.outputs.append(outputs.MatplotlibPlot(*args, **kwargs))
+        self.outputs.append(outputs.MatplotlibPlot(**kwargs))
         return self
 
-    def to_extrema_printer(self, *args, **kwargs) -> 'PlotLosses':
+    def to_extrema_printer(self, **kwargs) -> 'PlotLosses':
         """Appends outputs.ExtremaPrinter output, with specified parameters.
+
+        Args:
+            **kwargs: keyword arguments for ExtremaPrinter
 
         Returns:
             Plotlosses object (so it works for chaining)
         """
-        self.outputs.append(outputs.ExtremaPrinter(*args, **kwargs))
+        self.outputs.append(outputs.ExtremaPrinter(**kwargs))
+        return self
+
+    def to_bokeh(self, **kwargs) -> 'PlotLosses':
+        """Appends outputs.BokehPlot output, with specified parameters.
+
+        Args:
+            **kwargs: keyword arguments for BokehPlot
+
+        Returns:
+            Plotlosses object (so it works for chaining)
+        """
+        self.outputs.append(outputs.BokehPlot(**kwargs))
+        return self
+
+    def to_neptune(self, **kwargs) -> 'PlotLosses':
+        """Appends outputs.NeptuneLogger output, with specified parameters.
+
+        Args:
+            **kwargs: keyword arguments for NeptuneLogger
+
+        Returns:
+            Plotlosses object (so it works for chaining)
+        """
+        self.outputs.append(outputs.NeptuneLogger(**kwargs))
+        return self
+
+    def to_tensorboard(self, **kwargs) -> 'PlotLosses':
+        """Appends outputs.TensorboardLogger output, with specified parameters.
+
+        Args:
+            **kwargs: keyword arguments for TensorboardLogger
+
+        Returns:
+            Plotlosses object (so it works for chaining)
+        """
+        self.outputs.append(outputs.TensorboardLogger(**kwargs))
+        return self
+
+    def to_tensorboard_tf(self, **kwargs) -> 'PlotLosses':
+        """Appends outputs.TensorboardTFLogger output, with specified parameters.
+
+        Args:
+            **kwargs: keyword arguments for TensorboardTFLogger
+
+        Returns:
+            Plotlosses object (so it works for chaining)
+        """
+        self.outputs.append(outputs.TensorboardTFLogger(**kwargs))
         return self

--- a/livelossplot/plot_losses.py
+++ b/livelossplot/plot_losses.py
@@ -38,7 +38,7 @@ class PlotLosses:
         warnings.warn('draw will be deprecated, please use send method', PendingDeprecationWarning)
         self.send()
 
-    def reset_outputs(self) -> PlotLosses:
+    def reset_outputs(self) -> 'PlotLosses':
         """Resets all outputs.
 
         Returns:
@@ -47,7 +47,7 @@ class PlotLosses:
         self.outputs = []
         return self
 
-    def to_matplotlib(self, *args, **kwargs) -> PlotLosses:
+    def to_matplotlib(self, *args, **kwargs) -> 'PlotLosses':
         """Appends outputs.MatplotlibPlot output, with specified parameters.
 
         Returns:
@@ -56,7 +56,7 @@ class PlotLosses:
         self.outputs.append(MatplotlibPlot(*args, **kwargs))
         return self
 
-    def to_extrema_printer(self, *args, **kwargs) -> PlotLosses:
+    def to_extrema_printer(self, *args, **kwargs) -> 'PlotLosses':
         """Appends outputs.ExtremaPrinter output, with specified parameters.
 
         Returns:

--- a/tests/test_plot_losses.py
+++ b/tests/test_plot_losses.py
@@ -18,7 +18,7 @@ class CheckOutput(BaseOutput):
 
 def test_plot_losses():
     """Test basic usage"""
-    loss_plotter = PlotLosses(outputs=(CheckOutput(), ))
+    loss_plotter = PlotLosses(outputs=[CheckOutput()])
     loss_plotter.update({'acc': 0.5, 'val_acc': 0.4, 'loss': 1.2, 'val_loss': 1.1})
     loss_plotter.update({
         'acc': 0.55,
@@ -30,3 +30,13 @@ def test_plot_losses():
         'loss': 1.1,
     })
     loss_plotter.send()
+
+
+def test_plot_losses_to_outputs():
+    """Test PlotLosses.to_output API"""
+    plotlosses = PlotLosses(outputs=['MatplotlibPlot'])
+    assert len(plotlosses.outputs) == 1
+    plotlosses.reset_outputs()
+    assert len(plotlosses.outputs) == 0
+    plotlosses.to_matplotlib().to_extrema_printer().to_extrema_printer()
+    assert len(plotlosses.outputs) == 3


### PR DESCRIPTION
Adding a chainable way to specify outputs, without too many import lines, see #113 by @vfdev-5.

- [X] `reset_outputs`, `to_matplotlib`, `to_extrema_printer`
- [x] checking if it actually works
- [x] tests
- [x] following with all other outputs