### PR TITLE
Dropping support for Python 3.5

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+## Dropped
+
+- Support for Python 3.5.
+
 ## [0.5.3] - 2020-07-24
 
 ## Added

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,9 @@ def version():
 setup(
     name='livelossplot',
     version=version(),
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=[
-        'ipython', 'matplotlib;python_version>="3.6"', 'matplotlib<3.1;python_version<"3.6"',
-        'numpy<1.18;python_version<"3.6"', 'bokeh;python_version>="3.6"', 'bokeh<=1.4.0;python_version<"3.6"'
+        'ipython', 'matplotlib', 'bokeh',
     ],
     description='Live training loss plot in Jupyter Notebook for Keras, PyTorch and others.',
     long_description=readme(),
@@ -45,7 +44,6 @@ setup(
         'Topic :: Scientific/Engineering :: Visualization',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
See #127. 

A long overdue change.

It simplifies testing process and installation instructions. 